### PR TITLE
force *nix style slashes in RecieveFile()

### DIFF
--- a/agent/collector/agent.go
+++ b/agent/collector/agent.go
@@ -136,7 +136,7 @@ func (agent *SSHAgent) ListDirectory(path string) ([]FileInfo, error) {
 }
 
 func (agent *SSHAgent) ReceiveFile(src, dest string, progressFn ProgressFunc) error {
-	src = filepath.Clean(src)
+	src = filepath.ToSlash(filepath.Clean(src))
 	dest = filepath.Clean(dest)
 
 	client, err := sftp.NewClient(agent.client)


### PR DESCRIPTION
This resolves an issue preventing Windows machines from pulling config files from a linux host- `filepath` assumes that any file path is local to the current host, so it swaps out `/` for `\` and you get complaints from RecieveFile() e.g.:

`Failed to receive config file '\etc\cassandra\conf\cassandra.yaml' (SSH agent: Failed to open source file over SFTP (file does not exist))` 

This is with settings.yml specifying node.cassandra.config-path as `/etc/cassandra/conf/`.