### PR TITLE
Agent. Generate config mode refactoring (Issue #47)

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -25,13 +25,13 @@ const knownHostsPath = "/.ssh/known_hosts"
 const defaultPrivateKeyPath = "/.ssh/id_rsa"
 
 var (
-	user               = flag.String("l", "", "User to log in as on the remote machine")
-	port               = flag.Int("p", 22, "Port to connect to on the remote host")
-	disableKnownHosts  = flag.Bool("disable_known_hosts", false, "Skip loading the user’s known-hosts file")
-	mcTimeRangeFrom    = flag.String("mc-from", "", "Datetime (RFC3339 format, 2006-01-02T15:04:05Z07:00) to fetch metrics from some time point. (Default 1970-01-01 00:00:00 +0000 UTC)")
-	mcTimeRangeTo      = flag.String("mc-to", "", "Datetime (RFC3339 format, 2006-01-02T15:04:05Z07:00) to fetch metrics to some time point. (Default current datetime)")
-	configPath         = flag.String("config", "", "The path to the configuration file")
-	generateConfigPath = flag.String("generate-config", "", "The path where the default settings file will be created")
+	user              = flag.String("l", "", "User to log in as on the remote machine")
+	port              = flag.Int("p", 22, "Port to connect to on the remote host")
+	disableKnownHosts = flag.Bool("disable_known_hosts", false, "Skip loading the user’s known-hosts file")
+	mcTimeRangeFrom   = flag.String("mc-from", "", "Datetime (RFC3339 format, 2006-01-02T15:04:05Z07:00) to fetch metrics from some time point. (Default 1970-01-01 00:00:00 +0000 UTC)")
+	mcTimeRangeTo     = flag.String("mc-to", "", "Datetime (RFC3339 format, 2006-01-02T15:04:05Z07:00) to fetch metrics to some time point. (Default current datetime)")
+	configPath        = flag.String("config", "", "The path to the configuration file")
+	generateConfig    = flag.Bool("generate-config", false, "Generates the default settings file")
 
 	mcTargets   StringList
 	ncTargets   StringList
@@ -81,14 +81,24 @@ func main() {
 		Target:  *TargetDefaultSettings(),
 	}
 
-	if len(*generateConfigPath) > 0 {
-		err := settings.Save(*generateConfigPath)
+	if *generateConfig {
+		generateConfigPath := Expand(SearchSettingsPath(flag.Arg(0)))
+
+		if len(mcTargets.items) > 0 {
+			settings.Target.Metrics = mcTargets.items[:1]
+		}
+		if len(ncTargets.items) > 0 {
+			settings.Target.Nodes = ncTargets.items
+		}
+
+		err := settings.Save(generateConfigPath)
 		if err != nil {
 			log.Warn("Failed to create default settings file: " + err.Error())
 		} else {
-			log.Info("The default settings '", *generateConfigPath, "' file cleared")
+			log.Info("The default settings '", generateConfigPath, "' file created")
 		}
 
+		return
 	}
 
 	settingsPath := Expand(SearchSettingsPath(*configPath))
@@ -101,7 +111,7 @@ func main() {
 		}
 	} else {
 		log.Warn("The settings file '", settingsPath, "' does not exists")
-		if len(*generateConfigPath) <= 0 {
+		if !*generateConfig {
 			log.Warn("Use '-generate-config' option to create file with default settings")
 		}
 	}

--- a/agent/utils.go
+++ b/agent/utils.go
@@ -71,7 +71,8 @@ func printParameterUsage(parameter *flag.Flag) {
 }
 
 func parseAndValidateCommandLineArguments() {
-	if *user == "" {
+
+	if *user == "" && !*generateConfig {
 		flag.Usage()
 		os.Exit(1)
 	}

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -13,7 +13,10 @@ To agent supports the following command line flags:
 * `-p int` - Port to connect to on the remote host (default 22) via SSH
 * `-pk PATH` - List of files from which the identification keys (private key) for public key authentication are read, in addition to default one (Default [HOME]/.ssh/id_rsa)
 * `-config PATH` - The path to the configuration file
-* `generate-config PATH` - The path where the default settings file will be created
+* `-generate-config` - Generates the configuration file template in the default location  
+`... -generate-config /var/foo/bar.yaml` - Generates the configuration file template located at /var/foo/bar.yaml  
+`... -nc 1.2.3.4 -generate-config /var/foo/bar.yaml` - Generates the configuration file template located at /var/foo/bar.yaml, and pre-populates a node ip  
+**NOTE** _The location to the configuration file must be on the last command line argument_
 
 E.g. `./agent -disable_known_hosts -l ubuntu -mc 10.0.56.1 -nc 10.0.0.1,10.0.0.2,10.0.0.3,10.0.0.4 -pk ~/.ssh/id_rsa`
 


### PR DESCRIPTION
Generate config mode refactoring (Issue #47)
NOTE: The location to the configuration file must be on the last command line argument, because of Go "flag" lib limitations